### PR TITLE
✅ Add backend tests

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -94,6 +94,10 @@ dependencies {
     testImplementation("org.springframework.security:spring-security-test")
     testImplementation("com.h2database:h2")
     implementation("com.drewnoakes:metadata-extractor:2.18.0")
+    testImplementation("org.junit.jupiter:junit-jupiter-api")
+    testImplementation("io.mockk:mockk:1.13.2")
+    testImplementation("io.kotest:kotest-runner-junit5:5.5.4")
+    testImplementation("io.kotest:kotest-assertions-core:5.5.4")
 }
 
 tasks.withType<KotlinCompile> {
@@ -116,7 +120,7 @@ tasks.jacocoTestReport {
     reports {
         xml.required.set(true)
         csv.required.set(false)
-        html.required.set(false)
+        html.required.set(true)
     }
 }
 

--- a/backend/src/main/kotlin/com/swpp/footprinter/domain/trace/service/TraceService.kt
+++ b/backend/src/main/kotlin/com/swpp/footprinter/domain/trace/service/TraceService.kt
@@ -118,7 +118,7 @@ class TraceServiceImpl(
                         p.imageUrl = imageUrlUtil.getImageURLfromImagePath(p.imagePath)
                     }
                 }
-                footprints = footprints?.sortedBy{ stringToDate8601(it.startTime).time }
+                footprints = footprints?.sortedBy { stringToDate8601(it.startTime).time }
             }
     }
 

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -67,8 +67,8 @@ spring.config.activate.on-profile: test
 
 spring:
   datasource:
-    url: jdbc:h2:mem:testdb;MODE=MYSQL;DATABASE_TO_UPPER=false;DB_CLOSE_DELAY=-1;
+    url: jdbc:h2:mem:testdb;MODE=MYSQL;DATABASE_TO_UPPER=false;DB_CLOSE_DELAY=-1;NON_KEYWORDS=user
   jpa:
     generate-ddl: true
     hibernate:
-      ddl-auto: create
+      ddl-auto: create-drop

--- a/backend/src/test/kotlin/com/swpp/footprinter/domain/footprint/service/FootprintServiceTest.kt
+++ b/backend/src/test/kotlin/com/swpp/footprinter/domain/footprint/service/FootprintServiceTest.kt
@@ -1,0 +1,78 @@
+package com.swpp.footprinter.domain.footprint.service
+
+import com.swpp.footprinter.domain.footprint.dto.FootprintResponse
+import com.swpp.footprinter.domain.footprint.model.Footprint
+import com.swpp.footprinter.domain.footprint.repository.FootprintRepository
+import com.swpp.footprinter.domain.place.model.Place
+import com.swpp.footprinter.domain.place.repository.PlaceRepository
+import com.swpp.footprinter.domain.tag.TAG_CODE
+import com.swpp.footprinter.domain.tag.model.Tag
+import com.swpp.footprinter.domain.tag.repository.TagRepository
+import com.swpp.footprinter.domain.trace.model.Trace
+import com.swpp.footprinter.domain.trace.repository.TraceRepository
+import com.swpp.footprinter.domain.user.model.User
+import com.swpp.footprinter.domain.user.repository.UserRepository
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.BeforeEach
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.transaction.annotation.Transactional
+import java.util.*
+
+@SpringBootTest
+@Transactional
+internal class FootprintServiceTest @Autowired constructor(
+    @Autowired private val footprintService: FootprintService,
+    @Autowired private val footprintRepo: FootprintRepository,
+    @Autowired private val placeRepo: PlaceRepository,
+    @Autowired private val tagRepo: TagRepository,
+    @Autowired private val userRepo: UserRepository,
+    @Autowired private val traceRepo: TraceRepository
+) {
+
+    @BeforeEach
+    fun setup() {
+        val user = userRepo.save(User(username = "User1", email = "test@snu.ac.kr", myTrace = mutableSetOf()))
+        val place = placeRepo.save(Place("Test Place", "Test Address", mutableSetOf()))
+        val tag = tagRepo.save(Tag(TAG_CODE.음식점, mutableSetOf()))
+        val trace = traceRepo.save(Trace("Test Title", "Test Date", user, mutableSetOf()))
+        footprintRepo.save(
+            Footprint(
+                startTime = Date(System.currentTimeMillis()),
+                endTime = Date(System.currentTimeMillis()),
+                rating = 2,
+                memo = "TEST",
+                place = place,
+                tag = tag,
+                trace = trace,
+            )
+        )
+    }
+
+    @Test
+    fun `should get footprint by id`() {
+        val footprint = footprintService.getFootprintById(1)
+
+        assertThat(footprint).isExactlyInstanceOf(FootprintResponse::class.java)
+        assertThat(footprint.id).isEqualTo(1)
+        assertThat(footprint.rating).isEqualTo(2)
+        assertThat(footprint.memo).isEqualTo("TEST")
+        assertThat(footprint.place.name).isEqualTo("Test Place")
+        assertThat(footprint.tag.tagName).isEqualTo("음식점")
+        assertThat(footprint.traceId).isEqualTo(1)
+    }
+
+    @Test
+    fun createFootprintAndReturn() {
+    }
+
+    @Test
+    fun editFootprint() {
+    }
+
+    @Test
+    fun deleteFootprintById() {
+    }
+}


### PR DESCRIPTION
- mockk, kotest 등 test dependency를 추가했습니다.
- jacoco coverage report를 html 형식으로도 볼 수 있게 했습니다. `backend/build/reports/jacoco/test/html/index.html`

![jacocohtml](https://user-images.githubusercontent.com/40167175/201457101-25c9b152-b412-40f8-90f4-6bb9d844df7a.png)


> [참고한 Test](https://github.com/wafflestudio/snutt-ev/blob/develop/core/src/test/kotlin/com/wafflestudio/snuttev/core/domain/evaluation/service/EvaluationServiceTest.kt)

