### PR TITLE
🐛 Fixed Login with Invalid Token (Frontend)

### DIFF
--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -6,7 +6,8 @@ import { useAuthStore } from "../store/auth";
 
 export default function Home() {
   const router = useRouter();
-  const token = useAuthStore((state) => state.userToken)
+  const token = useAuthStore((state) => state.userToken);
+  const setToken = useAuthStore((state) => state.setToken);
   useQuery(
     ["token valid", token],
     () => {
@@ -15,6 +16,7 @@ export default function Home() {
     {
       onSuccess: (result) => {
         if (!result.valid) {
+          setToken("");
           router.push("/signin");
         } else {
           router.push("/footprints");

--- a/frontend/pages/signin/index.tsx
+++ b/frontend/pages/signin/index.tsx
@@ -1,12 +1,12 @@
-import { useMutation } from "@tanstack/react-query";
+import { useMutation, useQuery } from "@tanstack/react-query";
 import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
 import toast from "react-hot-toast";
-import { postSignin, postSignUp } from "../../api";
+import { checkToken, postSignin, postSignUp } from "../../api";
 import RectangleButton from "../../components/buttons/RectangleButton";
 import Container from "../../components/containers/Container";
 import TextField from "../../components/textfield/TextField";
-import { SigninRequestType } from "../../dto/auth";
+import { SigninRequestType, TokenVerifyResponseType } from "../../dto/auth";
 import ErrorResponse from "../../dto/exception";
 import { useAuthStore } from "../../store/auth";
 
@@ -18,6 +18,16 @@ export default function Signin() {
   const router = useRouter();
   const setToken = useAuthStore((state) => state.setToken);
   const userToken = useAuthStore((state) => state.userToken);
+
+  useEffect(() => {
+    checkToken({token: userToken})
+      .then((response: TokenVerifyResponseType) => {
+        if (response.valid) {
+          setToken(userToken);
+          router.push("/footprints");
+        }
+      })
+  }, [router, setToken, userToken]);
 
   return (
     <Container>

--- a/frontend/pages/signin/index.tsx
+++ b/frontend/pages/signin/index.tsx
@@ -25,7 +25,12 @@ export default function Signin() {
         if (response.valid) {
           setToken(userToken);
           router.push("/footprints");
+        } else {
+          setToken("");
         }
+      })
+      .catch(() => {
+        setToken("");
       })
   }, [router, setToken, userToken]);
 

--- a/frontend/pages/signin/index.tsx
+++ b/frontend/pages/signin/index.tsx
@@ -19,14 +19,6 @@ export default function Signin() {
   const setToken = useAuthStore((state) => state.setToken);
   const userToken = useAuthStore((state) => state.userToken);
 
-  useEffect(() => {
-    if (!userToken) {
-      return;
-    }
-    setToken(userToken);
-    router.push("/footprints");
-  }, [router, setToken, userToken]);
-
   return (
     <Container>
       <div className="mx-5 flex min-h-screen items-center justify-center">


### PR DESCRIPTION
- Token이 존재는 하나 잘못된 경우 (expire되었거나 token 안에 있는 유저가  존재하지 않을 시) Footprints 페이지와 Login 페이지를 무한으로 왕복하는 문제가 있었습니다.
- 그 원인이 login 페이지에서 useEffect에서 token이 비어있는지만 확인해서 비어있으면 footprint로 보내고, 이 과정에서 token은 유효하지 않으므로 다시 login페이지로 보내고, 이런 과정이 반복되서 그런 거 같습니다.
- useEffect에서 checkToken을 통해서 단순히 비어있는것이 아닌 맞는 token인지 체크하도록 수정하였습니다.
  - 그러나 async를 사용해서 그런지 이미 로그인되어있는 상태에서 signin으로 직접 이동 시 signin 페이지가 잠깐 나온 뒤 footprints로 redirect되는 현상이 있습니다...