### PR TITLE
✨Implement trace view count

### DIFF
--- a/backend/src/main/kotlin/com/swpp/footprinter/domain/trace/api/TraceController.kt
+++ b/backend/src/main/kotlin/com/swpp/footprinter/domain/trace/api/TraceController.kt
@@ -4,6 +4,7 @@ import com.swpp.footprinter.common.annotations.UserContext
 import com.swpp.footprinter.domain.footprint.dto.FootprintInitialTraceResponse
 import com.swpp.footprinter.domain.trace.dto.TraceDetailResponse
 import com.swpp.footprinter.domain.trace.dto.TraceRequest
+import com.swpp.footprinter.domain.trace.dto.TraceViewResponse
 import com.swpp.footprinter.domain.trace.service.TraceService
 import com.swpp.footprinter.domain.user.model.User
 import org.springframework.http.HttpStatus
@@ -70,5 +71,12 @@ class TraceController(
         @RequestBody photoPathList: List<String>,
     ): List<FootprintInitialTraceResponse> {
         return service.createInitialTraceBasedOnPhotoIdListGiven(photoPathList)
+    }
+
+    @PostMapping("/view/{traceId}")
+    fun updateTraceViewCount(
+        @PathVariable(required = true) traceId: Long,
+    ): TraceViewResponse {
+        return service.updateViewCount(traceId)
     }
 }

--- a/backend/src/main/kotlin/com/swpp/footprinter/domain/trace/dto/TraceDetailResponse.kt
+++ b/backend/src/main/kotlin/com/swpp/footprinter/domain/trace/dto/TraceDetailResponse.kt
@@ -7,5 +7,6 @@ class TraceDetailResponse(
     val date: String?,
     val title: String?,
     val ownerName: String?,
-    var footprints: List<FootprintResponse>?
+    var footprints: List<FootprintResponse>?,
+    val viewCount: Int
 )

--- a/backend/src/main/kotlin/com/swpp/footprinter/domain/trace/dto/TraceViewResponse.kt
+++ b/backend/src/main/kotlin/com/swpp/footprinter/domain/trace/dto/TraceViewResponse.kt
@@ -1,0 +1,5 @@
+package com.swpp.footprinter.domain.trace.dto
+
+data class TraceViewResponse(
+    val viewCount: Int
+)

--- a/backend/src/main/kotlin/com/swpp/footprinter/domain/trace/model/Trace.kt
+++ b/backend/src/main/kotlin/com/swpp/footprinter/domain/trace/model/Trace.kt
@@ -30,6 +30,9 @@ class Trace(
     @Column(name = "likes_count", columnDefinition = "integer default 0")
     var likesCount: Int = 0,
 
+    @Column(name = "view_count", columnDefinition = "integer default 0")
+    var viewCount: Int = 0,
+
 ) : BaseEntity() {
     fun toResponse(): TraceResponse {
         return TraceResponse(
@@ -46,7 +49,8 @@ class Trace(
             date = traceDate,
             title = traceTitle,
             ownerName = owner.username,
-            footprints = footprints.map { it.toResponse(imageUrlUtil) }
+            footprints = footprints.map { it.toResponse(imageUrlUtil) },
+            viewCount = viewCount
         )
     }
 }

--- a/backend/src/main/kotlin/com/swpp/footprinter/domain/trace/service/TraceService.kt
+++ b/backend/src/main/kotlin/com/swpp/footprinter/domain/trace/service/TraceService.kt
@@ -19,6 +19,7 @@ import com.swpp.footprinter.domain.tag.TAG_CODE
 import com.swpp.footprinter.domain.tag.dto.TagResponse
 import com.swpp.footprinter.domain.trace.dto.TraceDetailResponse
 import com.swpp.footprinter.domain.trace.dto.TraceRequest
+import com.swpp.footprinter.domain.trace.dto.TraceViewResponse
 import com.swpp.footprinter.domain.trace.model.Trace
 import com.swpp.footprinter.domain.trace.repository.TraceRepository
 import com.swpp.footprinter.domain.user.model.User
@@ -35,10 +36,10 @@ interface TraceService {
     fun getAllOtherUsersTraces(loginUser: User): List<TraceDetailResponse>
     fun createTrace(traceRequest: TraceRequest, loginUser: User)
     fun getTraceById(traceId: Long): TraceDetailResponse
-
     fun deleteTraceById(traceId: Long, loginUser: User)
     fun createInitialTraceBasedOnPhotoIdListGiven(photoIds: List<String>): List<FootprintInitialTraceResponse> // List<Pair<Place, List<Photo>>>
     fun getTraceByDate(date: String, loginUser: User): TraceDetailResponse?
+    fun updateViewCount(traceId: Long): TraceViewResponse
 }
 
 @Service
@@ -126,6 +127,15 @@ class TraceServiceImpl(
                     stringToDate8601(it.startTime).time
                 }
             }
+    }
+
+    @Transactional
+    override fun updateViewCount(traceId: Long): TraceViewResponse {
+        val targetTrace = traceRepo.findByIdOrNull(traceId) ?: throw FootprinterException(ErrorType.NOT_FOUND)
+
+        targetTrace.viewCount++
+
+        return TraceViewResponse(targetTrace.viewCount)
     }
 
     /**

--- a/backend/src/test/kotlin/com/swpp/footprinter/domain/user/service/UserServiceTest.kt
+++ b/backend/src/test/kotlin/com/swpp/footprinter/domain/user/service/UserServiceTest.kt
@@ -65,12 +65,12 @@ class UserServiceTest @Autowired constructor(
         user.myTrace.add(trace)
 
         // when
-        val traceResponseListReturned = userService.getUserTraces(user.id!!)
+        val traceResponseListReturned = userService.getUserTraces(user.id)
 
         // then
         val traceResponseListExpected = listOf(
             TraceResponse(
-                id = trace.id!!,
+                id = trace.id,
                 date = trace.traceDate,
                 title = trace.traceTitle,
                 ownerId = user.id
@@ -117,15 +117,16 @@ class UserServiceTest @Autowired constructor(
         user.myTrace.add(trace2)
 
         // when
-        val traceDetailResponseReturned = userService.getUserTraceByDate(user.id!!, "2022-11-11")
+        val traceDetailResponseReturned = userService.getUserTraceByDate(user.id, "2022-11-11")
 
         // then
         val traceDetailResponseExpected = TraceDetailResponse(
-            id = trace2.id!!,
+            id = trace2.id,
             date = trace2.traceDate,
             title = trace2.traceTitle,
             ownerName = user.username,
             footprints = listOf(),
+            viewCount = 0
         )
 
         assertThat(traceDetailResponseReturned?.id).isEqualTo(traceDetailResponseExpected.id)
@@ -133,6 +134,7 @@ class UserServiceTest @Autowired constructor(
         assertThat(traceDetailResponseReturned?.title).isEqualTo(traceDetailResponseExpected.title)
         assertThat(traceDetailResponseReturned?.ownerName).isEqualTo(traceDetailResponseExpected.ownerName)
         assertThat(traceDetailResponseReturned?.footprints).isEmpty()
+        assertThat(traceDetailResponseReturned?.viewCount).isEqualTo(traceDetailResponseExpected.viewCount)
     }
 
     @Test

--- a/frontend/api/index.ts
+++ b/frontend/api/index.ts
@@ -1,5 +1,5 @@
 import { FootprintPredictionType } from "../dto/recommendations";
-import { TraceDetailResponseType, TraceRequestType } from "../dto/trace";
+import { TraceDetailResponseType, TraceRequestType, TraceViewResponseType } from "../dto/trace";
 import { apiClient } from "./client";
 import moment from "moment";
 import { TagType } from "../dto/tag";
@@ -57,4 +57,8 @@ export const postSignUp = async (signinRequest: SigninRequestType) => {
 
 export const checkToken = async (tokenVerifyRequest: TokenVerifyRequestType) => {
   return (await apiClient.post<TokenVerifyResponseType>("/token", tokenVerifyRequest)).data;
+};
+
+export const updateViewCount = async (traceId: number) => {
+  return (await apiClient.post<TraceViewResponseType>(`/traces/view/${traceId}`)).data;
 };

--- a/frontend/components/navbar/MenuDropdown.tsx
+++ b/frontend/components/navbar/MenuDropdown.tsx
@@ -20,7 +20,9 @@ const MenuDropdown = () => {
         {
           icon: IconMapSearch,
           text: "탐색하기",
-          onClick: () => {},
+          onClick: () => {
+            router.push("/traces/explore")
+          },
         },
       ]}
     />

--- a/frontend/components/trace/OwnerInfo.tsx
+++ b/frontend/components/trace/OwnerInfo.tsx
@@ -1,12 +1,9 @@
-import Image from "next/image";
+import OwnerProfilePhoto from "./OwnerProfilePhoto";
 
 const OwnerInfo = (profile: { username: string }) => {
     return (
         <div className="flex">
-            <div className="ml-10 relative h-12 w-12 overflow-hidden rounded-full border border-gray-700">
-                <Image fill src={""} alt={""} className="object-cover" sizes="33vw" priority />
-                
-            </div>
+            <OwnerProfilePhoto imageUrl="https://images.unsplash.com/photo-1669072596436-15df4a8c083d?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=987&q=80" />
             <div className="text-base p-3 text-center">
                 {profile.username}
             </div>

--- a/frontend/components/trace/OwnerInfo.tsx
+++ b/frontend/components/trace/OwnerInfo.tsx
@@ -1,10 +1,12 @@
+import { useRouter } from "next/router";
 import OwnerProfilePhoto from "./OwnerProfilePhoto";
 
 const OwnerInfo = (profile: { username: string }) => {
+    const router = useRouter();
     return (
         <div className="flex">
             <OwnerProfilePhoto imageUrl="https://images.unsplash.com/photo-1669072596436-15df4a8c083d?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=987&q=80" />
-            <div className="text-base p-3 text-center">
+            <div className="text-base p-3 text-center hover:cursor-pointer" onClick={() => router.push(`/user/${profile.username}`)}>
                 {profile.username}
             </div>
         </div>

--- a/frontend/components/trace/OwnerInfo.tsx
+++ b/frontend/components/trace/OwnerInfo.tsx
@@ -4,7 +4,7 @@ import OwnerProfilePhoto from "./OwnerProfilePhoto";
 const OwnerInfo = (profile: { username: string }) => {
     const router = useRouter();
     return (
-        <div className="flex">
+        <div className="flex pt-3">
             <OwnerProfilePhoto imageUrl="https://images.unsplash.com/photo-1669072596436-15df4a8c083d?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=987&q=80" />
             <div className="text-base p-3 text-center hover:cursor-pointer" onClick={() => router.push(`/user/${profile.username}`)}>
                 {profile.username}

--- a/frontend/components/trace/OwnerProfilePhoto.tsx
+++ b/frontend/components/trace/OwnerProfilePhoto.tsx
@@ -1,0 +1,11 @@
+import Image from "next/image";
+
+const OwnerProfilePhoto = (photo: { imageUrl: string }) => {
+    return (
+        <div className="ml-10 relative h-12 w-12 overflow-hidden rounded-full border border-gray-700">
+            <Image fill src={photo.imageUrl} alt={""} className="object-cover" sizes="33vw" priority />
+        </div>
+    )
+}
+
+export default OwnerProfilePhoto;

--- a/frontend/dto/trace.ts
+++ b/frontend/dto/trace.ts
@@ -13,4 +13,9 @@ export interface TraceDetailResponseType {
   title: string;
   ownerName: string;
   footprints: FootprintResponseType[];
+  viewCount: number;
+}
+
+export interface TraceViewResponseType {
+  viewCount: number;
 }

--- a/frontend/pages/traces/detail/[traceId].tsx
+++ b/frontend/pages/traces/detail/[traceId].tsx
@@ -10,21 +10,24 @@ export default function TraceDetail() {
   const router = useRouter();
   const { traceId } = router.query;
 
-  useQuery(
-    ["updateViewCount", traceId], () => {
-      return updateViewCount(Number(traceId));
-    },
-    {
-      enabled: !!traceId
-    }
-  );
-
   const traceResult = useQuery(
     ["footprints", traceId], () => {
       return fetchTraceById(Number(traceId));
     },
     {
-      enabled: !!traceId
+      enabled: !!traceId,
+      onError: () => {
+        router.back();
+      }
+    }
+  );
+
+  useQuery(
+    ["updateViewCount", traceId], () => {
+      return updateViewCount(Number(traceId));
+    },
+    {
+      enabled: traceResult.isSuccess,
     }
   );
 

--- a/frontend/pages/traces/detail/[traceId].tsx
+++ b/frontend/pages/traces/detail/[traceId].tsx
@@ -1,7 +1,7 @@
 import Container from "../../../components/containers/Container";
 import NavigationBar from "../../../components/navbar/NavigationBar";
 import { useQuery } from "@tanstack/react-query";
-import { fetchTraceById } from "../../../api";
+import { fetchTraceById, updateViewCount } from "../../../api";
 import NavbarContainer from "../../../components/containers/NavbarContainer";
 import { FootprintPreview } from "../../../components/footprint/FootprintPreview";
 import { useRouter } from "next/router";
@@ -10,9 +10,23 @@ export default function TraceDetail() {
   const router = useRouter();
   const { traceId } = router.query;
 
-  const traceResult = useQuery(["footprints", traceId], () => {
-    return fetchTraceById(Number(traceId));
-  });
+  useQuery(
+    ["updateViewCount", traceId], () => {
+      return updateViewCount(Number(traceId));
+    },
+    {
+      enabled: !!traceId
+    }
+  );
+
+  const traceResult = useQuery(
+    ["footprints", traceId], () => {
+      return fetchTraceById(Number(traceId));
+    },
+    {
+      enabled: !!traceId
+    }
+  );
 
   return (
     <Container>

--- a/frontend/pages/traces/explore/index.tsx
+++ b/frontend/pages/traces/explore/index.tsx
@@ -27,7 +27,7 @@ export default function Explore() {
                             <OwnerInfo username={String(trace.ownerName)} />
                             <div className="pl-40 pt-3 items-center flex divide-x divide-navy-500 text-xs leading-3 text-navy-400">
                                     <span className="px-2">좋아요 {0}</span>
-                                    <span className="px-2">{0}명 조회</span>
+                                    <span className="px-2">{trace.viewCount}명 조회</span>
                             </div>
                         </div>
                         

--- a/frontend/pages/traces/explore/index.tsx
+++ b/frontend/pages/traces/explore/index.tsx
@@ -18,12 +18,19 @@ export default function Explore() {
 
             {traceExploreResult.isSuccess && traceExploreResult.data.length == 0 && <TracesNotFound />}
 
-            <div className="divide-y divide-navy-700/50 pb-20">
+            <div className="divide-y divide-navy-700/50 pb-10">
                 {traceExploreResult.data?.map((trace) => {
                     return ( 
-                    <div key = {trace.id}>
+                    <div key = {trace.id} className="py-2">
                         <TracePreview {...trace} />
-                        <OwnerInfo username={String(trace.ownerName)} />
+                        <div className="flex">
+                            <OwnerInfo username={String(trace.ownerName)} />
+                            <div className="pl-40 pt-3 items-center flex divide-x divide-navy-500 text-xs leading-3 text-navy-400">
+                                    <span className="px-2">좋아요 {0}</span>
+                                    <span className="px-2">{0}명 조회</span>
+                            </div>
+                        </div>
+                        
                     </div>
                     );
                 })}

--- a/frontend/tests/unit/api/index.test.ts
+++ b/frontend/tests/unit/api/index.test.ts
@@ -1,5 +1,6 @@
 import { act } from "@testing-library/react";
-import { editFootprint, fetchFootprintById, fetchInitialFootprints, fetchTraceById } from "../../../api";
+import { editFootprint, fetchAllOtherUsersTraces, fetchAllUserTraces, fetchFootprintById, fetchInitialFootprints, fetchTraceById, postSignin, postSignUp } from "../../../api";
+import { SigninRequestType } from "../../../dto/auth";
 import { FootprintEditRequestType, FootprintRequestType } from "../../../dto/footprint";
 import mockAxios from "../../../__mocks__/axios";
 
@@ -14,6 +15,11 @@ const footprintRequestStub: FootprintEditRequestType = {
   },
   tagId: 0,
   memo: "",
+};
+
+const authRequestStub: SigninRequestType = {
+  username: "",
+  password: "",
 };
 
 it("fetch footprints", async () => {
@@ -44,6 +50,38 @@ it("fetch fetchFootprintById", async () => {
   mockAxios.get.mockResolvedValue({ data: "mock" });
   await act(async () => {
     const data = await fetchFootprintById(5);
+    expect(data).toBe("mock");
+  });
+});
+
+it("fetch fetchAllUserTraces", async () => {
+  mockAxios.get.mockResolvedValue({ data: "mock" });
+  await act(async () => {
+    const data = await fetchAllUserTraces("user1");
+    expect(data).toBe("mock");
+  });
+});
+
+it("fetch fetchAllOtherUsersTraces", async () => {
+  mockAxios.get.mockResolvedValue({ data: "mock" });
+  await act(async () => {
+    const data = await fetchAllOtherUsersTraces();
+    expect(data).toBe("mock");
+  });
+});
+
+it("post postSignin", async () => {
+  mockAxios.post.mockResolvedValue({ data: "mock" });
+  await act(async () => {
+    const data = await postSignin(authRequestStub);
+    expect(data).toBe("mock");
+  });
+});
+
+it("post postSignUp", async () => {
+  mockAxios.post.mockResolvedValue({ data: "mock" });
+  await act(async () => {
+    const data = await postSignUp(authRequestStub);
     expect(data).toBe("mock");
   });
 });

--- a/frontend/tests/unit/components/TraceNotFound.test.tsx
+++ b/frontend/tests/unit/components/TraceNotFound.test.tsx
@@ -1,0 +1,7 @@
+import { render } from "@testing-library/react";
+import TracesNotFound from "../../../components/placeholder/TracesNotFound";
+
+it("renders placeholder", () => {
+  render(<TracesNotFound />);
+  expect(window).toBeTruthy();
+});

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -5,8 +5,9 @@ sonar.projectName=swppfall2022-team5
 sonar.projectVersion=1.0
 sonar.sourceEncoding=UTF-8
 
-sonar.sources=backend/src/main/kotlin,frontend/pages, frontend/api, frontend/components, frontend/store
+sonar.sources=backend/src/main/kotlin,frontend/pages,frontend/api,frontend/components,frontend/store
 sonar.tests=backend/src/test,frontend/tests
+sonar.exclusions=backend/src/main/kotlin/**/test
 
 sonar.javascript.lcov.reportPaths=artifacts/frontend-coverage/lcov.info
 sonar.coverage.jacoco.xmlReportPaths=artifacts/backend-coverage/jacocoTestReport.xml


### PR DESCRIPTION
Figma 디자인대로 탐색 페이지에 Trace의 좋아요 수와 조회수가 표시되도록 구현했습니다.
조회수는 Trace detail page에 접속하거나 그 페이지에서 새로고침을 하면 단순 1씩 증가하도록 구현했습니다.
좋아요 수는 아직 0으로 나오도록 냅뒀습니다.