### PR TITLE
🚑️ Fixed overuse of memory & optimized query of searching trace.

### DIFF
--- a/backend/src/main/kotlin/com/swpp/footprinter/domain/trace/repository/TraceRepository.kt
+++ b/backend/src/main/kotlin/com/swpp/footprinter/domain/trace/repository/TraceRepository.kt
@@ -75,8 +75,7 @@ class TraceRepositoryCustomImpl(
         }
 
         val traces = jpaQueryFactory
-            .select(trace)
-            .from(trace, user, footprint, place, tag)
+            .selectFrom(trace)
             .join(trace.owner, user)
             .join(trace.footprints, footprint)
             .join(footprint.place, place)

--- a/backend/src/main/kotlin/com/swpp/footprinter/domain/trace/repository/TraceRepository.kt
+++ b/backend/src/main/kotlin/com/swpp/footprinter/domain/trace/repository/TraceRepository.kt
@@ -76,10 +76,10 @@ class TraceRepositoryCustomImpl(
 
         val traces = jpaQueryFactory
             .selectFrom(trace)
-            .join(trace.owner, user)
-            .join(trace.footprints, footprint)
-            .join(footprint.place, place)
-            .join(footprint.tag, tag)
+            .join(trace.owner, user).fetchJoin()
+            .join(trace.footprints, footprint).fetchJoin()
+            .join(footprint.place, place).fetchJoin()
+            .join(footprint.tag, tag).fetchJoin()
             .where(booleanBuilder)
             .orderBy(trace.traceDate.desc())
             .fetch()


### PR DESCRIPTION
Search Trace를 하기 위해 query 하는 도중 여러 테이블 정보를 중복적으로 불러와 메모리를 과하게 사용하던 버그를 고쳤습니다.