### PR TITLE
🔒️ Fix error that allow user to edit or delete footprint without ownership

### DIFF
--- a/backend/src/main/kotlin/com/swpp/footprinter/domain/footprint/api/FootprintController.kt
+++ b/backend/src/main/kotlin/com/swpp/footprinter/domain/footprint/api/FootprintController.kt
@@ -1,8 +1,10 @@
 package com.swpp.footprinter.domain.footprint.api
 
+import com.swpp.footprinter.common.annotations.UserContext
 import com.swpp.footprinter.domain.footprint.dto.FootprintRequest
 import com.swpp.footprinter.domain.footprint.dto.FootprintResponse
 import com.swpp.footprinter.domain.footprint.service.FootprintService
+import com.swpp.footprinter.domain.user.model.User
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -30,15 +32,17 @@ class FootprintController(
     @PutMapping("/footprints/{footprintId}")
     fun editFootprintById(
         @PathVariable footprintId: Long,
-        @RequestBody @Valid request: FootprintRequest
+        @RequestBody @Valid request: FootprintRequest,
+        @UserContext loginUser: User
     ) {
-        service.editFootprint(footprintId, request)
+        service.editFootprint(loginUser, footprintId, request)
     }
 
     @DeleteMapping("/footprints/{footprintId}")
     fun deleteFootprintById(
-        @PathVariable footprintId: Long
+        @PathVariable footprintId: Long,
+        @UserContext loginUser: User
     ) {
-        service.deleteFootprintById(footprintId)
+        service.deleteFootprintById(loginUser, footprintId)
     }
 }

--- a/backend/src/main/kotlin/com/swpp/footprinter/domain/footprint/model/Footprint.kt
+++ b/backend/src/main/kotlin/com/swpp/footprinter/domain/footprint/model/Footprint.kt
@@ -40,11 +40,11 @@ class Footprint(
 
     fun toResponse(imageUrlUtil: ImageUrlUtil): FootprintResponse {
         return FootprintResponse(
-            id = id!!,
+            id = id,
             startTime = dateToString8601(startTime),
             endTime = dateToString8601(endTime),
             rating = rating,
-            traceId = trace.id!!,
+            traceId = trace.id,
             place = place.toResponse(),
             tag = tag.toResponse(),
             memo = memo,

--- a/backend/src/test/kotlin/com/swpp/footprinter/domain/footprint/service/FootprintServiceTest.kt
+++ b/backend/src/test/kotlin/com/swpp/footprinter/domain/footprint/service/FootprintServiceTest.kt
@@ -9,6 +9,7 @@ import com.swpp.footprinter.domain.footprint.dto.FootprintResponse
 import com.swpp.footprinter.domain.footprint.repository.FootprintRepository
 import com.swpp.footprinter.domain.photo.dto.PhotoRequest
 import com.swpp.footprinter.domain.photo.repository.PhotoRepository
+import com.swpp.footprinter.domain.photo.service.PhotoService
 import com.swpp.footprinter.domain.place.dto.PlaceRequest
 import com.swpp.footprinter.domain.place.repository.PlaceRepository
 import com.swpp.footprinter.domain.tag.TAG_CODE
@@ -23,6 +24,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.mockito.ArgumentMatchers.anyString
 import org.mockito.InjectMocks
+import org.mockito.Mockito
 import org.mockito.Mockito.`when`
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
@@ -37,6 +39,7 @@ import java.util.*
 internal class FootprintServiceTest @Autowired constructor(
     private val testHelper: TestHelper,
     @MockBean val mockImageUrlUtil: ImageUrlUtil,
+    @MockBean val mockPhotoService: PhotoService,
     @InjectMocks private val footprintService: FootprintService,
     private val footprintRepo: FootprintRepository,
     private val placeRepo: PlaceRepository,
@@ -46,11 +49,21 @@ internal class FootprintServiceTest @Autowired constructor(
     private val photoRepo: PhotoRepository,
 ) {
 
+    object MockitoHelper {
+        fun <T> anyObject(): T {
+            Mockito.any<T>()
+            return uninitialized()
+        }
+        @Suppress("UNCHECKED_CAST")
+        fun <T> uninitialized(): T = null as T
+    }
     @BeforeAll
     fun initialSetup() {
+
         testHelper.createUser("testUser", "test@snu.ac.kr")
         testHelper.initializeTag()
         `when`(mockImageUrlUtil.getImageURLfromImagePath(anyString())).thenReturn("testURL")
+        `when`(mockPhotoService.deletePhotoFromDatabaseAndServer(MockitoHelper.anyObject())).then { print("mocking") }
     }
 
     @AfterEach

--- a/backend/src/test/kotlin/com/swpp/footprinter/domain/footprint/service/FootprintServiceTest.kt
+++ b/backend/src/test/kotlin/com/swpp/footprinter/domain/footprint/service/FootprintServiceTest.kt
@@ -9,7 +9,6 @@ import com.swpp.footprinter.domain.footprint.dto.FootprintResponse
 import com.swpp.footprinter.domain.footprint.repository.FootprintRepository
 import com.swpp.footprinter.domain.photo.dto.PhotoRequest
 import com.swpp.footprinter.domain.photo.repository.PhotoRepository
-import com.swpp.footprinter.domain.photo.service.PhotoService
 import com.swpp.footprinter.domain.place.dto.PlaceRequest
 import com.swpp.footprinter.domain.place.repository.PlaceRepository
 import com.swpp.footprinter.domain.tag.TAG_CODE
@@ -24,7 +23,6 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.mockito.ArgumentMatchers.anyString
 import org.mockito.InjectMocks
-import org.mockito.Mockito
 import org.mockito.Mockito.`when`
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
@@ -39,7 +37,6 @@ import java.util.*
 internal class FootprintServiceTest @Autowired constructor(
     private val testHelper: TestHelper,
     @MockBean val mockImageUrlUtil: ImageUrlUtil,
-    @MockBean val mockPhotoService: PhotoService,
     @InjectMocks private val footprintService: FootprintService,
     private val footprintRepo: FootprintRepository,
     private val placeRepo: PlaceRepository,
@@ -49,21 +46,11 @@ internal class FootprintServiceTest @Autowired constructor(
     private val photoRepo: PhotoRepository,
 ) {
 
-    object MockitoHelper {
-        fun <T> anyObject(): T {
-            Mockito.any<T>()
-            return uninitialized()
-        }
-        @Suppress("UNCHECKED_CAST")
-        fun <T> uninitialized(): T = null as T
-    }
     @BeforeAll
     fun initialSetup() {
-
         testHelper.createUser("testUser", "test@snu.ac.kr")
         testHelper.initializeTag()
         `when`(mockImageUrlUtil.getImageURLfromImagePath(anyString())).thenReturn("testURL")
-        `when`(mockPhotoService.deletePhotoFromDatabaseAndServer(MockitoHelper.anyObject())).then { print("mocking") }
     }
 
     @AfterEach

--- a/backend/src/test/kotlin/com/swpp/footprinter/domain/footprint/service/FootprintServiceTest.kt
+++ b/backend/src/test/kotlin/com/swpp/footprinter/domain/footprint/service/FootprintServiceTest.kt
@@ -9,7 +9,6 @@ import com.swpp.footprinter.domain.footprint.dto.FootprintResponse
 import com.swpp.footprinter.domain.footprint.repository.FootprintRepository
 import com.swpp.footprinter.domain.photo.dto.PhotoRequest
 import com.swpp.footprinter.domain.photo.repository.PhotoRepository
-import com.swpp.footprinter.domain.photo.service.PhotoService
 import com.swpp.footprinter.domain.place.dto.PlaceRequest
 import com.swpp.footprinter.domain.place.repository.PlaceRepository
 import com.swpp.footprinter.domain.tag.TAG_CODE
@@ -38,7 +37,6 @@ import java.util.*
 internal class FootprintServiceTest @Autowired constructor(
     private val testHelper: TestHelper,
     @MockBean val mockImageUrlUtil: ImageUrlUtil,
-    @MockBean val mockPhotoService: PhotoService,
     @InjectMocks private val footprintService: FootprintService,
     private val footprintRepo: FootprintRepository,
     private val placeRepo: PlaceRepository,
@@ -77,7 +75,7 @@ internal class FootprintServiceTest @Autowired constructor(
             photos = mutableSetOf(testHelper.createPhoto("TestPath", 0.0, 0.0, Date(), null))
         )
 
-        val footprint = footprintService.getFootprintById(testFootprint.id!!)
+        val footprint = footprintService.getFootprintById(testFootprint.id)
 
         assertThat(footprint).isExactlyInstanceOf(FootprintResponse::class.java)
         assertThat(footprint).extracting("rating").isEqualTo(2)
@@ -220,22 +218,22 @@ internal class FootprintServiceTest @Autowired constructor(
         )
 
         try {
-            footprintService.editFootprint(99, footprintRequest)
+            footprintService.editFootprint(user, 99, footprintRequest)
             assertThat(true).isFalse
         } catch (e: FootprinterException) {
             assertThat(e).extracting("errorType").isEqualTo(ErrorType.NOT_FOUND)
         }
 
         try {
-            footprintService.editFootprint(testFootprint.id!!, wrongFootprintRequest)
+            footprintService.editFootprint(user, testFootprint.id, wrongFootprintRequest)
             assertThat(true).isFalse
         } catch (e: FootprinterException) {
             assertThat(e).extracting("errorType").isEqualTo(ErrorType.WRONG_FORMAT)
         }
 
-        footprintService.editFootprint(testFootprint.id!!, footprintRequest)
+        footprintService.editFootprint(user, testFootprint.id, footprintRequest)
 
-        val footprint = footprintRepo.findByIdOrNull(testFootprint.id!!)!!
+        val footprint = footprintRepo.findByIdOrNull(testFootprint.id)!!
 
         assertThat(footprint).extracting("memo").isEqualTo("TESTEDIT")
         assertThat(footprint).extracting("rating").isEqualTo(1)
@@ -253,9 +251,9 @@ internal class FootprintServiceTest @Autowired constructor(
             photos = listOf(PhotoRequest("TestPath2", 0.0, 0.0, dateToString8601(Date())))
         )
 
-        footprintService.editFootprint(testFootprint.id!!, anotherRequest)
+        footprintService.editFootprint(user, testFootprint.id, anotherRequest)
 
-        val anotherFootprint = footprintRepo.findByIdOrNull(testFootprint.id!!)!!
+        val anotherFootprint = footprintRepo.findByIdOrNull(testFootprint.id)!!
 
         assertThat(anotherFootprint).extracting("memo").isEqualTo("TESTEDIT2")
         assertThat(anotherFootprint).extracting("rating").isEqualTo(2)
@@ -278,12 +276,12 @@ internal class FootprintServiceTest @Autowired constructor(
             photos = mutableSetOf(testHelper.createPhoto("TestPath", 0.0, 0.0, Date(), null))
         )
 
-        val footprint = footprintRepo.findByIdOrNull(testFootprint.id!!)
+        val footprint = footprintRepo.findByIdOrNull(testFootprint.id)
         assertThat(footprint).isNotNull
 
-        footprintService.deleteFootprintById(testFootprint.id!!)
+        footprintService.deleteFootprintById(user, testFootprint.id)
 
-        val test = footprintRepo.findByIdOrNull(testFootprint.id!!)
+        val test = footprintRepo.findByIdOrNull(testFootprint.id)
         assertThat(test).isNull()
     }
 }


### PR DESCRIPTION
우선 백엔드에서 자신이 작성하지 않은 footprint를 수정&삭제하려고 하는 경우 403에러가 뜨도록 했습니다.

시간이 된다면 프론트엔드에서 수정이나 삭제 버튼이 렌더링 되지 않도록 구현해볼게요